### PR TITLE
Add metric definition to get correct graph units

### DIFF
--- a/ovirt_plugin/2.0/local/share/check_mk/web/metrics/ovirt.py
+++ b/ovirt_plugin/2.0/local/share/check_mk/web/metrics/ovirt.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from cmk.gui.plugins.metrics.translation import df_translation
+
+check_metrics["check_mk-ovirt_storage_domains"] = df_translation
+


### PR DESCRIPTION
Graph showed MB instead of TB. The metric definition was missing.
![2024-08-02_17h58_57](https://github.com/user-attachments/assets/88195417-77c3-4c8a-8a50-a010a8cc0e86)
![2024-08-02_17h59_42](https://github.com/user-attachments/assets/a1137cac-c3b9-4702-8d10-4584b1ecaf07)
![2024-08-02_18h01_07](https://github.com/user-attachments/assets/4e9a12c5-522b-4621-a622-5b5fd6a61370)

